### PR TITLE
Basic styling

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,56 @@
  *= require_self
  */
 
+@import url("https://fonts.googleapis.com/css2?family=Roboto&display=swap");
+
+:root {
+  --font-main: "Roboto", "Arial", sans-serif;
+}
+
 body {
-  font-family: sans-serif;
+  font-family: var(--font-main);
+}
+
+button,
+input[type="text"],
+input[type="number"],
+input[type="submit"] {
+  padding: 5px 10px;
+  font-family: var(--font-main);
+}
+
+.flash {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 400px;
+  max-width: 100%;
+  height: 50px;
+  background: #EEE;
+  border: 1px solid #888;
+  color: #888;
+  border-radius: 10px;
+  text-align: center;
+  line-height: 50px;
+  animation: 5s fadeout 1 forwards;
+  user-select: none;
+}
+
+.flash-notice {
+  background: #CFC;
+  border: 1px solid #080;
+  color: #080;
+}
+
+.flash-alert {
+  background: #FCC;
+  border: 1px solid #800;
+  color: #800;
+}
+
+@keyframes fadeout {
+  0% {opacity: 1;}
+  50% {opacity: 1;}
+  100% {opacity: 0;}
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,7 @@
 
 :root {
   --font-main: "Roboto", "Arial", sans-serif;
+  --safe-width: calc(100% - 20px);
 }
 
 body {
@@ -33,19 +34,24 @@ input[type="submit"] {
 }
 
 .flash {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   position: fixed;
   top: 10px;
   left: 50%;
   transform: translate(-50%, 0);
-  width: 400px;
-  max-width: 100%;
-  height: 50px;
+  min-width: min(400px, var(--safe-width));
+  max-width: var(--safe-width);
+  min-height: 50px;
+  padding: 10px 20px;
+  box-sizing: border-box;
   background: #EEE;
   border: 1px solid #888;
   color: #888;
   border-radius: 10px;
   text-align: center;
-  line-height: 50px;
   animation: 5s fadeout 1 forwards;
   user-select: none;
 }


### PR DESCRIPTION
Added some basic styling to make the app a bit more presentable for demos.

This PR only modifies `app/assets/stylesheets/application.css`, so there should be no merge conflicts.

- Buttons and input fields now have slight padding
- Flash notices are now styled
  - Green for success (`flash[:notice]`), red for failure (`flash[:alert]`)
  - Displays for 2500 ms and fades out over the next 2500 ms.
  - Flash notices are mobile-compatible, but a `<meta name="viewport" ...>` tag will need to be added later (needed anyway for proper mobile support).
- Font changed to Roboto, served from Google Fonts (previously `sans-serif`, which could be different across systems)

![image](https://github.com/MAES-Rewards/maes-rewards/assets/24465111/f9a97f3a-2dba-47eb-a0e4-9793407eba28)

![image](https://github.com/MAES-Rewards/maes-rewards/assets/24465111/f9586ab1-4df7-4b11-9f33-bf8fad2c2d83)