### PR TITLE
Ability to grant members points for an activity in bulk.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,9 +28,15 @@ body {
 button,
 input[type="text"],
 input[type="number"],
-input[type="submit"] {
+input[type="submit"],
+select {
   padding: 5px 10px;
   font-family: var(--font-main);
+}
+
+input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
 }
 
 .flash {
@@ -72,4 +78,8 @@ input[type="submit"] {
   0% {opacity: 1;}
   50% {opacity: 1;}
   100% {opacity: 0;}
+}
+
+.hidden {
+  display: none;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,13 +13,20 @@ class UsersController < ApplicationController
       @users = User.where(is_admin: false).order(:name)
     else
       redirect_to destroy_admin_session_path
+    end
 
   end
 
   # execute point assignment by using selected user ids, point amount, and associated activity
   def handle_points
-    if session[is_admin]
+    if session[:is_admin]
       @users = User.where(is_admin: false).order(:name)
+
+      @selected_activity = nil
+
+      if params[:recur_activity_id].present?
+        @selected_activity = Activity.find_by(id: params[:recur_activity_id])
+      end
 
       # selected fields
       selected_user_ids = params[:selected_users]
@@ -59,6 +66,7 @@ class UsersController < ApplicationController
       redirect_to(admin_dashboard_path)
     else
       redirect_to destroy_admin_session_path
+    end
   end
 
   def new; end
@@ -99,10 +107,13 @@ class UsersController < ApplicationController
   def destroy
     if session[:is_admin]
       User.find(params[:id]).destroy!
+      redirect_to(admin_dashboard_path)
+      flash[:notice] = 'User successfully deleted.'
     else
       flash[:alert] = 'Access denied. Please log in as an admin.'
+      redirect_to(destroy_admin_session_path)
     end
-    redirect_to(destroy_admin_session_path)
+
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,43 +7,58 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  # find all non-admin users to assign points in bulk
   def points
-    @users = User.where(is_admin: false).order(:name)
+    if (session[:is_admin])
+      @users = User.where(is_admin: false).order(:name)
+    else
+      redirect_to destroy_admin_session_path
 
   end
 
+  # execute point assignment by using selected user ids, point amount, and associated activity
   def handle_points
-    @users = User.where(is_admin: false).order(:name)
-    selected_user_ids = params[:selected_users]
-    new_points = params[:new_points]
-    recur_activity_id = params[:recur_activity_id]
-    onetime_activity_string = params[:onetime_activity_string]
+    if session[is_admin]
+      @users = User.where(is_admin: false).order(:name)
 
-    if recur_activity_id.blank? && onetime_activity_string.blank?
-      flash[:alert] = 'Please select or enter an activity.'
-      redirect_to(admin_dashboard_path) and return
-    end
+      # selected fields
+      selected_user_ids = params[:selected_users]
+      new_points = params[:new_points]
+      recur_activity_id = params[:recur_activity_id]
+      onetime_activity_string = params[:onetime_activity_string]
 
-    if !recur_activity_id.blank? && !onetime_activity_string.blank?
-      flash[:alert] = 'Cannot enter values for both recurring and one time activity.'
-      redirect_to(admin_dashboard_path) and return
-    end
-
-    selected_user_ids ||= []
-    saved = true
-    selected_user_ids.each do |user_id|
-      user = User.find(user_id)
-      user.points += new_points.to_i
-      unless user.save!
-        saved = false
+      # check if for activity associated one-time & recurring, both are blank or both are selected
+      if recur_activity_id.blank? && onetime_activity_string.blank?
+        flash[:alert] = 'Please select or enter an activity.'
+        redirect_to(admin_dashboard_path) and return
       end
-    end
-    if saved
-      flash[:notice] = 'User(s) were successfully updated.'
+
+      if !recur_activity_id.blank? && !onetime_activity_string.blank?
+        flash[:alert] = 'Cannot enter values for both recurring and one time activity.'
+        redirect_to(admin_dashboard_path) and return
+      end
+
+      # iterate through selected users and assign points
+      selected_user_ids ||= []
+      saved = true
+      selected_user_ids.each do |user_id|
+        user = User.find(user_id)
+        user.points += new_points.to_i
+        unless user.save!
+          saved = false
+        end
+      end
+
+      # check if saved, create corresponding flash notice
+      if saved
+        flash[:notice] = 'User(s) were successfully updated.'
+      else
+        flash[:notice] = 'User(s) were not updated successfully.'
+      end
+      # redirect to landing page
+      redirect_to(admin_dashboard_path)
     else
-      flash[:notice] = 'User(s) were not updated successfully.'
-    end
-    redirect_to(admin_dashboard_path)
+      redirect_to destroy_admin_session_path
   end
 
   def new; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,18 @@ class UsersController < ApplicationController
     @users = User.where(is_admin: false).order(:name)
     selected_user_ids = params[:selected_users]
     new_points = params[:new_points]
-    activity_id = params[:activity_id]
+    recur_activity_id = params[:recur_activity_id]
+    onetime_activity_string = params[:onetime_activity_string]
+
+    if recur_activity_id.blank? && onetime_activity_string.blank?
+      flash[:alert] = 'Please select or enter an activity.'
+      redirect_to(admin_dashboard_path) and return
+    end
+
+    if !recur_activity_id.blank? && !onetime_activity_string.blank?
+      flash[:alert] = 'Cannot enter values for both recurring and one time activity.'
+      redirect_to(admin_dashboard_path) and return
+    end
 
     selected_user_ids ||= []
     saved = true
@@ -28,9 +39,9 @@ class UsersController < ApplicationController
       end
     end
     if saved
-      flash[:notice] = 'Users were successfully updated.'
+      flash[:notice] = 'User(s) were successfully updated.'
     else
-      flash[:notice] = 'Users were not updated successfully.'
+      flash[:notice] = 'User(s) were not updated successfully.'
     end
     redirect_to(admin_dashboard_path)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def points
+    @users = User.where(is_admin: false).order(:name)
+  end
+
   def new; end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,30 @@ class UsersController < ApplicationController
 
   def points
     @users = User.where(is_admin: false).order(:name)
+
+  end
+
+  def handle_points
+    @users = User.where(is_admin: false).order(:name)
+    selected_user_ids = params[:selected_users]
+    new_points = params[:new_points]
+    activity_id = params[:activity_id]
+
+    selected_user_ids ||= []
+    saved = true
+    selected_user_ids.each do |user_id|
+      user = User.find(user_id)
+      user.points += new_points.to_i
+      unless user.save!
+        saved = false
+      end
+    end
+    if saved
+      flash[:notice] = 'Users were successfully updated.'
+    else
+      flash[:notice] = 'Users were not updated successfully.'
+    end
+    redirect_to(admin_dashboard_path)
   end
 
   def new; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,33 +37,41 @@ class UsersController < ApplicationController
       # check if for activity associated one-time & recurring, both are blank or both are selected
       if recur_activity_id.blank? && onetime_activity_string.blank?
         flash[:alert] = 'Please select or enter an activity.'
-        redirect_to(admin_dashboard_path) and return
+        redirect_to(member_points_url) and return
       end
 
       if !recur_activity_id.blank? && !onetime_activity_string.blank?
         flash[:alert] = 'Cannot enter values for both recurring and one time activity.'
-        redirect_to(admin_dashboard_path) and return
+        redirect_to(member_points_url) and return
       end
+
+
 
       # iterate through selected users and assign points
       selected_user_ids ||= []
       saved = true
       selected_user_ids.each do |user_id|
         user = User.find(user_id)
-        user.points += new_points.to_i
-        unless user.save!
-          saved = false
+        if (user.points + new_points.to_i < 0 || user.points + new_points.to_i > 2147483647)
+          flash[:alert] = 'Enter a valid point value.'
+          redirect_to(member_points_url) and return
+        else
+          user.points += new_points.to_i
+          unless user.save!
+            saved = false
+          end
         end
       end
 
       # check if saved, create corresponding flash notice
       if saved
         flash[:notice] = 'User(s) were successfully updated.'
+        redirect_to(admin_dashboard_path)
       else
-        flash[:notice] = 'User(s) were not updated successfully.'
+        flash[:alert] = 'User(s) were not updated successfully.'
+        redirect_to member_points_url
       end
       # redirect to landing page
-      redirect_to(admin_dashboard_path)
     else
       redirect_to destroy_admin_session_path
     end

--- a/app/views/dashboards/admin.html.erb
+++ b/app/views/dashboards/admin.html.erb
@@ -2,6 +2,7 @@
 <%= link_to "Sign Out", destroy_admin_session_path %>
 <%= link_to "View Rewards", rewards_path%>
 <%= link_to "Activities", activities_path%>
+<%= link_to "Assign Points", member_points_url%>
 
 
 <table>

--- a/app/views/dashboards/admin.html.erb
+++ b/app/views/dashboards/admin.html.erb
@@ -23,3 +23,10 @@
         </tr>
     <% end %>
 </table>
+
+
+<% flash.each do |type, message| %>
+    <div class="flash flash-<%= type %>">
+      <%= message %>
+    </div>
+  <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,8 +1,10 @@
-<h1>My Account</h1>
+
 
 <% if session[:is_admin] %>
+  <h1><%=@user.name%>'s Account</h1>
   <%= link_to("Go back to landing page", admin_dashboard_url)%>
 <% else %>
+  <h1>Edit My Account</h1>
   <%= link_to("Go back to My Account", user_path(@user))%><br>
 <%end%>
 
@@ -28,5 +30,3 @@
     <%= message %>
   </div>
 <% end %>
-
-

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -1,9 +1,8 @@
 
 <h1>Assign Points to Members</h1>
+<h3>Member List:</h3>
+<%= form_tag handle_points_path, method: :post do %>
 <table>
-    <tr>
-        <th>Name</th>
-    </tr>
     <% @users.each do |user| %>
         <tr>
             <td><%= user.name %>, (<%=user.points %> points)</td>
@@ -11,11 +10,15 @@
         </tr>
     <% end %>
 </table>
+<hr>
 <%= label_tag "new_points", "Points:" %>
-<%= number_field_tag "new_points", nil, min: 0 %>
+<%= number_field_tag "new_points", nil %>
 <br />
-<%= label_tag "activity", "Activity:" %>
+<br />
+<%= label_tag "activity", "Associated Activity:" %>
 <%= select_tag "activity_id", options_for_select(Activity.order(:name).map { |activity| [activity.name, activity.id] }, include_blank: true), id: "id_of_the_activity_id_select_box" %>
 <br />
+<br />
 
-<%= link_to("Submit", handle_points_path)%>
+<%= submit_tag "Submit" %>
+<% end %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -65,6 +65,14 @@
 <hr>
 <br />
 <%= submit_tag "Submit" %>
+
+<% flash.each do |type, message| %>
+  <div class="flash flash-<%= type %>">
+    <%= message %>
+  </div>
+<% end %>
+
+
 <script>
 
     // JavaScript for custom activity selection

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -4,8 +4,14 @@
 <%= link_to("Go back to landing page", admin_dashboard_url)%>
 <h3>Member List:</h3>
 
+<!-- search bar -->
+<div>
+  <%= label_tag "search", "Search:" %>
+  <%= text_field_tag "search", nil, id: "search_bar" %>
+</div>
+
 <%= form_tag handle_points_path, method: :post do %>
-<table>
+<table id="member_table">
     <! -- list of non-admin users with checkbox to select each one -->
     <% @users.each do |user| %>
         <tr>
@@ -46,6 +52,8 @@
 <br />
 <%= submit_tag "Submit" %>
 <script>
+
+    // JavaScript for custom activity selection
     const actSelect = document.getElementById("activity_select_box");
     const actCustom = document.getElementById("onetime_activity_section");
     const actCustomInput = document.getElementById("onetime_activity_string");
@@ -59,5 +67,21 @@
             actCustomInput.value = "";
         }
     });
+
+    // JavaScript for filtering members based on the search bar
+    const searchInput = document.getElementById("search_bar");
+    const memberTable = document.getElementById("member_table");
+
+    searchInput.addEventListener("input", () => {
+      const searchQuery = searchInput.value.toLowerCase();
+      const rows = memberTable.querySelectorAll("tr");
+
+      rows.forEach(row => {
+        const userName = row.querySelector("td:first-child").textContent.toLowerCase();
+        const isVisible = userName.includes(searchQuery);
+        row.style.display = isVisible ? "table-row" : "none";
+      });
+    });
+
 </script>
 <% end %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -4,11 +4,23 @@
 <%= link_to("Go back to landing page", admin_dashboard_url)%>
 <h3>Member List:</h3>
 
-<!-- search bar -->
+<!-- search bar & buttons -->
 <div>
   <%= label_tag "search", "Search:" %>
   <%= text_field_tag "search", nil, id: "search_bar" %>
+  <!-- Filter selected users button -->
+  <button type="button" onclick="filterSelectedUsers()">Show Selected Users</button>
+<!-- Show all users button -->
+  <button type="button" onclick="showAllUsers()">Show All Users</button>
+<!-- Select all users button -->
+  <button type="button" onclick="selectAllUsers()">Select All Users</button>
+<!-- Deselect all users button -->
+  <button type="button" onclick="deselectAllUsers()">Deselect All Users</button>
+
 </div>
+<br />
+
+
 
 <%= form_tag handle_points_path, method: :post do %>
 <table id="member_table">
@@ -20,10 +32,7 @@
         </tr>
     <% end %>
 </table>
-<!-- Filter selected users button -->
-  <button type="button" onclick="filterSelectedUsers()">Show Selected Users</button>
-<!-- Show all users button -->
-  <button type="button" onclick="showAllUsers()">Show All Users</button>
+
 
 <br />
 <hr>
@@ -105,6 +114,22 @@
       const rows = memberTable.querySelectorAll(".member_row");
       rows.forEach(row => {
         row.style.display = "table-row";
+      });
+    }
+
+    // JavaScript for selecting all users
+    function selectAllUsers() {
+      const checkboxes = document.querySelectorAll(".member_row input[type='checkbox']");
+      checkboxes.forEach(checkbox => {
+        checkbox.checked = true;
+      });
+    }
+
+    // JavaScript for deselecting all users
+    function deselectAllUsers() {
+      const checkboxes = document.querySelectorAll(".member_row input[type='checkbox']");
+      checkboxes.forEach(checkbox => {
+        checkbox.checked = false;
       });
     }
 

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -18,22 +18,46 @@
 <hr>
 <br />
 <! --assigned point amount -->
-<%= label_tag "new_points", "Points:" %>
-<%= number_field_tag "new_points", nil %>
-<br />
+<div>
+    <%= label_tag "new_points", "Points:" %>
+    <%= number_field_tag "new_points", nil %>
+</div>
 <br />
 
 <hr>
 <br />
 <! -- associated activity with the point assignment -->
-<%= label_tag "activity", "Associated Recurring Activity:" %>
-<%= select_tag "recur_activity_id", options_for_select([["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] }), id: "id_of_the_activity_id_select_box" %>
-<p> OR </p>
-<%= label_tag "activity", "Associated One-time Activity:" %>
-<%= text_field_tag "onetime_activity_string" %>
-<br />
+<div>
+    <%= label_tag "activity", "Associated Recurring Activity:" %>
+    <%=
+        select_tag "recur_activity_id",
+        options_for_select(
+            [["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] } + [["Custom One-Time Activity\u2026", nil]]
+        ),
+        id: "activity_select_box"
+    %>
+</div>
+<div id="onetime_activity_section" class="hidden" style="margin-top: 1em;">
+    <%= label_tag "activity", "Associated One-Time Activity:" %>
+    <%= text_field_tag "onetime_activity_string" %>
+</div>
 <br />
 <hr>
 <br />
 <%= submit_tag "Submit" %>
+<script>
+    const actSelect = document.getElementById("activity_select_box");
+    const actCustom = document.getElementById("onetime_activity_section");
+    const actCustomInput = document.getElementById("onetime_activity_string");
+
+    actSelect.addEventListener("change", event => {
+        if (event.target.selectedOptions[0]?.text == "Custom One-Time Activity\u2026") {
+            actCustom.classList.remove("hidden");
+        }
+        else {
+            actCustom.classList.add("hidden");
+            actCustomInput.value = "";
+        }
+    });
+</script>
 <% end %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -1,4 +1,5 @@
 <! -- Page which allows administrators/officers to assign points to several users with an associated point source -->
+<script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
 <h1>Assign Points to Members</h1>
 <%= link_to("Go back to landing page", admin_dashboard_url)%>
 <h3>Member List:</h3>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -11,10 +11,11 @@
         </tr>
     <% end %>
 </table>
-<%= label_tag "points", "Points:" %>
-<%= number_field_tag "points", nil, min: 0 %>
+<%= label_tag "new_points", "Points:" %>
+<%= number_field_tag "new_points", nil, min: 0 %>
 <br />
-<%= label_tag "points", "Activity:" %>
+<%= label_tag "activity", "Activity:" %>
 <%= select_tag "activity_id", options_for_select(Activity.order(:name).map { |activity| [activity.name, activity.id] }, include_blank: true), id: "id_of_the_activity_id_select_box" %>
 <br />
-<%= submit_tag "Submit" %>
+
+<%= link_to("Submit", handle_points_path)%>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -1,0 +1,20 @@
+
+<h1>Assign Points to Members</h1>
+<table>
+    <tr>
+        <th>Name</th>
+    </tr>
+    <% @users.each do |user| %>
+        <tr>
+            <td><%= user.name %>, (<%=user.points %> points)</td>
+            <td><%= check_box_tag "selected_users[]", user.id %></td>
+        </tr>
+    <% end %>
+</table>
+<%= label_tag "points", "Points:" %>
+<%= number_field_tag "points", nil, min: 0 %>
+<br />
+<%= label_tag "points", "Activity:" %>
+<%= select_tag "activity_id", options_for_select(Activity.order(:name).map { |activity| [activity.name, activity.id] }, include_blank: true), id: "id_of_the_activity_id_select_box" %>
+<br />
+<%= submit_tag "Submit" %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -14,12 +14,17 @@
 <table id="member_table">
     <! -- list of non-admin users with checkbox to select each one -->
     <% @users.each do |user| %>
-        <tr>
+        <tr class="member_row">
             <td><%= user.name %>, (<%=user.points %> points)</td>
             <td><%= check_box_tag "selected_users[]", user.id %></td>
         </tr>
     <% end %>
 </table>
+<!-- Filter selected users button -->
+  <button type="button" onclick="filterSelectedUsers()">Show Selected Users</button>
+<!-- Show all users button -->
+  <button type="button" onclick="showAllUsers()">Show All Users</button>
+
 <br />
 <hr>
 <br />
@@ -82,6 +87,26 @@
         row.style.display = isVisible ? "table-row" : "none";
       });
     });
+
+    // JavaScript for showing only selected users
+    function filterSelectedUsers() {
+      const selectedUserIds = Array.from(document.querySelectorAll(".member_row input:checked")).map(input => input.value);
+      const rows = memberTable.querySelectorAll(".member_row");
+
+      rows.forEach(row => {
+        const userId = row.querySelector("input").value;
+        const isVisible = selectedUserIds.includes(userId);
+        row.style.display = isVisible ? "table-row" : "none";
+      });
+    }
+
+    // JavaScript for showing all users
+    function showAllUsers() {
+      const rows = memberTable.querySelectorAll(".member_row");
+      rows.forEach(row => {
+        row.style.display = "table-row";
+      });
+    }
 
 </script>
 <% end %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -8,14 +8,16 @@
 <div>
   <%= label_tag "search", "Search:" %>
   <%= text_field_tag "search", nil, id: "search_bar" %>
-  <!-- Filter selected users button -->
-  <button type="button" onclick="filterSelectedUsers()">Show Selected Users</button>
-<!-- Show all users button -->
-  <button type="button" onclick="showAllUsers()">Show All Users</button>
-<!-- Select all users button -->
-  <button type="button" onclick="selectAllUsers()">Select All Users</button>
-<!-- Deselect all users button -->
-  <button type="button" onclick="deselectAllUsers()">Deselect All Users</button>
+  <!-- Show Selected Users button -->
+  <button type="button" id="showSelectedButton" onclick="showSelectedUsers()">Show Selected Users</button>
+  <!-- Show All Users button -->
+  <button type="button" id="showAllButton" onclick="showAllUsers()" style="display: none;">Show All Users</button>
+  <!-- Select All Users button -->
+  <button type="button" id="selectAllButton" onclick="selectAllUsers()">Select All Users</button>
+  <!-- Deselect All Users button -->
+  <button type="button" id="deselectAllButton" onclick="deselectAllUsers()" style="display: none;">Deselect All Users</button>
+
+
 
 </div>
 <br />
@@ -27,7 +29,7 @@
     <! -- list of non-admin users with checkbox to select each one -->
     <% @users.each do |user| %>
         <tr class="member_row">
-            <td><%= user.name %>, (<%=user.points %> points)</td>
+            <td><%= user.name %> (<%=user.email %>)</td>
             <td><%= check_box_tag "selected_users[]", user.id %></td>
         </tr>
     <% end %>
@@ -106,7 +108,13 @@
     });
 
     // JavaScript for showing only selected users
-    function filterSelectedUsers() {
+    function showSelectedUsers() {
+      const selectedButton = document.getElementById("showSelectedButton");
+      const allButton = document.getElementById("showAllButton");
+
+      selectedButton.style.display = "none";
+      allButton.style.display = "inline-block";
+
       const selectedUserIds = Array.from(document.querySelectorAll(".member_row input:checked")).map(input => input.value);
       const rows = memberTable.querySelectorAll(".member_row");
 
@@ -119,6 +127,12 @@
 
     // JavaScript for showing all users
     function showAllUsers() {
+      const selectedButton = document.getElementById("showSelectedButton");
+      const allButton = document.getElementById("showAllButton");
+
+      selectedButton.style.display = "inline-block";
+      allButton.style.display = "none";
+
       const rows = memberTable.querySelectorAll(".member_row");
       rows.forEach(row => {
         row.style.display = "table-row";
@@ -127,6 +141,12 @@
 
     // JavaScript for selecting all users
     function selectAllUsers() {
+      const selectButton = document.getElementById("selectAllButton");
+      const deselectButton = document.getElementById("deselectAllButton");
+
+      selectButton.style.display = "none";
+      deselectButton.style.display = "inline-block";
+
       const checkboxes = document.querySelectorAll(".member_row input[type='checkbox']");
       checkboxes.forEach(checkbox => {
         checkbox.checked = true;
@@ -135,6 +155,12 @@
 
     // JavaScript for deselecting all users
     function deselectAllUsers() {
+      const selectButton = document.getElementById("selectAllButton");
+      const deselectButton = document.getElementById("deselectAllButton");
+
+      selectButton.style.display = "inline-block";
+      deselectButton.style.display = "none";
+
       const checkboxes = document.querySelectorAll(".member_row input[type='checkbox']");
       checkboxes.forEach(checkbox => {
         checkbox.checked = false;

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -1,5 +1,6 @@
 <! -- Page which allows administrators/officers to assign points to several users with an associated point source -->
 <h1>Assign Points to Members</h1>
+<%= link_to("Go back to landing page", admin_dashboard_url)%>
 <h3>Member List:</h3>
 
 <%= form_tag handle_points_path, method: :post do %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -1,8 +1,10 @@
-
+<! -- Page which allows administrators/officers to assign points to several users with an associated point source -->
 <h1>Assign Points to Members</h1>
 <h3>Member List:</h3>
+
 <%= form_tag handle_points_path, method: :post do %>
 <table>
+    <! -- list of non-admin users with checkbox to select each one -->
     <% @users.each do |user| %>
         <tr>
             <td><%= user.name %>, (<%=user.points %> points)</td>
@@ -10,15 +12,26 @@
         </tr>
     <% end %>
 </table>
+<br />
 <hr>
+<br />
+<! --assigned point amount -->
 <%= label_tag "new_points", "Points:" %>
 <%= number_field_tag "new_points", nil %>
 <br />
 <br />
-<%= label_tag "activity", "Associated Activity:" %>
-<%= select_tag "activity_id", options_for_select(Activity.order(:name).map { |activity| [activity.name, activity.id] }, include_blank: true), id: "id_of_the_activity_id_select_box" %>
-<br />
-<br />
 
+<hr>
+<br />
+<! -- associated activity with the point assignment -->
+<%= label_tag "activity", "Associated Recurring Activity:" %>
+<%= select_tag "recur_activity_id", options_for_select([["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] }), id: "id_of_the_activity_id_select_box" %>
+<p> OR </p>
+<%= label_tag "activity", "Associated One-time Activity:" %>
+<%= text_field_tag "onetime_activity_string" %>
+<br />
+<br />
+<hr>
+<br />
 <%= submit_tag "Submit" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get 'rewards/handle_purchase/:id/:user_id', to: 'rewards#handle_purchase', as: 'handle_purchase'
   get 'users/index', to: 'users#index', as: 'users_index'
   get 'users/points', to: 'users#points', as: 'member_points'
+  get 'users/handle_points', to: 'users#handle_points', as: 'handle_points'
   # get 'rewards/new', to: 'rewards#new', as: new_reward_path
   # get 'rewards/edit' => 'rewards#edit'
   # get 'rewards/delete' => 'rewards#delete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,11 @@ Rails.application.routes.draw do
   get 'rewards/handle_purchase/:id/:user_id', to: 'rewards#handle_purchase', as: 'handle_purchase'
   get 'users/index', to: 'users#index', as: 'users_index'
   get 'users/points', to: 'users#points', as: 'member_points'
-  get 'users/handle_points', to: 'users#handle_points', as: 'handle_points'
+
+  post 'handle_points', to: 'users#handle_points', as: :handle_points
+
+
+
   # get 'rewards/new', to: 'rewards#new', as: new_reward_path
   # get 'rewards/edit' => 'rewards#edit'
   # get 'rewards/delete' => 'rewards#delete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get 'rewards/membershow/:id/:user_id', to: 'rewards#membershow', as: 'memshow_path'
   get 'rewards/handle_purchase/:id/:user_id', to: 'rewards#handle_purchase', as: 'handle_purchase'
   get 'users/index', to: 'users#index', as: 'users_index'
+  get 'users/points', to: 'users#points', as: 'member_points'
   # get 'rewards/new', to: 'rewards#new', as: new_reward_path
   # get 'rewards/edit' => 'rewards#edit'
   # get 'rewards/delete' => 'rewards#delete'


### PR DESCRIPTION
User story: "As an officer, I want to be able to grant members points for an activity in bulk, so I can quickly reward members at an activity without going through them one-by-one."
Implemented: points & handle_points actions in User controller, points page in User view. Only accessible to admin/officers. Able to connect with either a recurring activity or a one-time custom activity. 