### PR TITLE
Add Custom… option logic to bulk point addition

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -73,3 +73,7 @@ input[type="submit"] {
   50% {opacity: 1;}
   100% {opacity: 0;}
 }
+
+.hidden {
+  display: none;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -34,6 +34,11 @@ select {
   font-family: var(--font-main);
 }
 
+input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+}
+
 .flash {
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,7 +28,8 @@ body {
 button,
 input[type="text"],
 input[type="number"],
-input[type="submit"] {
+input[type="submit"],
+select {
   padding: 5px 10px;
   font-family: var(--font-main);
 }

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -27,13 +27,35 @@
 <br />
 <! -- associated activity with the point assignment -->
 <%= label_tag "activity", "Associated Recurring Activity:" %>
-<%= select_tag "recur_activity_id", options_for_select([["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] }), id: "id_of_the_activity_id_select_box" %>
-<p> OR </p>
-<%= label_tag "activity", "Associated One-time Activity:" %>
-<%= text_field_tag "onetime_activity_string" %>
+<%=
+    select_tag "recur_activity_id",
+    options_for_select(
+        [["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] } + [["Custom One-Time Event\u2026", nil]]
+    ),
+    id: "activity_select_box"
+%>
+<div id="onetime_activity_section" class="hidden" style="margin-top: 1em;">
+    <%= label_tag "activity", "Associated One-time Activity:" %>
+    <%= text_field_tag "onetime_activity_string" %>
+</div>
 <br />
 <br />
 <hr>
 <br />
 <%= submit_tag "Submit" %>
+<script>
+    const actSelect = document.getElementById("activity_select_box");
+    const actCustom = document.getElementById("onetime_activity_section");
+    const actCustomInput = document.getElementById("onetime_activity_string");
+
+    actSelect.addEventListener("change", event => {
+        if (event.target.selectedOptions[0]?.text == "Custom One-Time Event\u2026") {
+            actCustom.classList.remove("hidden");
+        }
+        else {
+            actCustom.classList.add("hidden");
+            actCustomInput.value = "";
+        }
+    });
+</script>
 <% end %>

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -30,12 +30,12 @@
 <%=
     select_tag "recur_activity_id",
     options_for_select(
-        [["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] } + [["Custom One-Time Event\u2026", nil]]
+        [["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] } + [["Custom One-Time Activity\u2026", nil]]
     ),
     id: "activity_select_box"
 %>
 <div id="onetime_activity_section" class="hidden" style="margin-top: 1em;">
-    <%= label_tag "activity", "Associated One-time Activity:" %>
+    <%= label_tag "activity", "Associated One-Time Activity:" %>
     <%= text_field_tag "onetime_activity_string" %>
 </div>
 <br />
@@ -49,7 +49,7 @@
     const actCustomInput = document.getElementById("onetime_activity_string");
 
     actSelect.addEventListener("change", event => {
-        if (event.target.selectedOptions[0]?.text == "Custom One-Time Event\u2026") {
+        if (event.target.selectedOptions[0]?.text == "Custom One-Time Activity\u2026") {
             actCustom.classList.remove("hidden");
         }
         else {

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -18,27 +18,29 @@
 <hr>
 <br />
 <! --assigned point amount -->
-<%= label_tag "new_points", "Points:" %>
-<%= number_field_tag "new_points", nil %>
-<br />
+<div>
+    <%= label_tag "new_points", "Points:" %>
+    <%= number_field_tag "new_points", nil %>
+</div>
 <br />
 
 <hr>
 <br />
 <! -- associated activity with the point assignment -->
-<%= label_tag "activity", "Associated Recurring Activity:" %>
-<%=
-    select_tag "recur_activity_id",
-    options_for_select(
-        [["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] } + [["Custom One-Time Activity\u2026", nil]]
-    ),
-    id: "activity_select_box"
-%>
+<div>
+    <%= label_tag "activity", "Associated Recurring Activity:" %>
+    <%=
+        select_tag "recur_activity_id",
+        options_for_select(
+            [["", nil]] + Activity.order(:name).map { |activity| [activity.name, activity.id] } + [["Custom One-Time Activity\u2026", nil]]
+        ),
+        id: "activity_select_box"
+    %>
+</div>
 <div id="onetime_activity_section" class="hidden" style="margin-top: 1em;">
     <%= label_tag "activity", "Associated One-Time Activity:" %>
     <%= text_field_tag "onetime_activity_string" %>
 </div>
-<br />
 <br />
 <hr>
 <br />


### PR DESCRIPTION
This PR is intended for the `bulk-points` branch.

I added logic for a Custom… option that shows the custom activity text field. I tested both cases and they work on my end.

I also added some basic styling for `<select>` elements and checkboxes.