### PR TITLE
Show transaction history on user edit page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -27,6 +27,8 @@
   <% end %>
 </div>
 
+<%= render(partial: 'txn_hist', locals: {txn_hist: @txn_hist}) %>
+
 <% flash.each do |type, message| %>
   <div class="flash flash-<%= type %>">
     <%= message %>


### PR DESCRIPTION
Previously was on the show page (`/users/N`), but we are not using the show page.

Now it is also on the edit page (`/users/N/edit`).