### PR TITLE
Style fixes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -291,7 +291,7 @@ nav a:active {
   background: var(--color-darker);
 }
 
-.menu-container {
+#menu_container {
   display: none;
 }
 
@@ -331,7 +331,7 @@ nav a:active {
     color: white;
   }
 
-  .menu-container {
+  #menu_container {
     border-radius: 5px;
     background: var(--color-main);
     display: inline-block;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -217,8 +217,7 @@ input[type="checkbox"] {
   display: none;
 }
 
-@media screen and (max-width: 600px) {
-
+@media screen and (max-width: 700px) {
   .logo{
     width: 150px;
     height: 150px;
@@ -302,7 +301,7 @@ nav a:active {
   display: none;
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 1000px) {
   nav {
     background: var(--color-main);
     padding: 10px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -192,6 +192,7 @@ input[type="checkbox"] {
   animation: 5s fadeout 1 forwards;
   user-select: none;
   pointer-events: none;
+  z-index: 2;
 }
 
 .flash-notice {
@@ -253,6 +254,11 @@ input[type="checkbox"] {
   thead{
       display:none;
   }
+
+  table:not(.table-no-header) tbody tr td:first-child {
+    font-size: 24px;
+    font-weight: bold;
+  }
 }
 
 nav {
@@ -310,6 +316,7 @@ nav a:active {
     transition: left 500ms, opacity 500ms;
     box-sizing: border-box;
     width: min(200px, var(--safe-width));
+    z-index: 1;
   }
 
   nav:not(.menu-shown) {
@@ -342,6 +349,7 @@ nav a:active {
     left: 10px;
     padding: 5px;
     box-shadow: 0 2px 5px rgb(0 0 0 / 0.2);
+    z-index: 1;
   }
 
   .bar1, .bar2, .bar3 {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -191,6 +191,7 @@ input[type="checkbox"] {
   text-align: center;
   animation: 5s fadeout 1 forwards;
   user-select: none;
+  pointer-events: none;
 }
 
 .flash-notice {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -20,6 +20,8 @@
   --font-main: "Roboto", "Arial", sans-serif;
   --safe-width: calc(100% - 20px);
   --color-main: rgb(77 131 86);
+  --color-dark: rgb(47 101 56);
+  --color-darker: rgb(17 71 26);
 }
 
 main {
@@ -31,7 +33,7 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--color-main);
+  background: var(--color-main);
   padding: 20px;
   border-radius: 10px 10px 0 0;
 }
@@ -72,27 +74,39 @@ h1, h2 {
   
 }
 
-.primary_link{
+/* Styling for links & buttons */
+.primary_link,
+button,
+input[type="button"],
+input[type="submit"],
+input[type="reset"] {
   display: inline-block; 
   padding: 10px 20px; 
-  background-color: var(--color-main); /* Button background color */
+  background: var(--color-main); /* Button background color */
   text-decoration: none; /* Remove underline from the link */ 
   border: none; 
   border-radius: 5px; /* Rounded corners */ 
-  cursor: pointer; 
-  font-weight: bold; 
-  transition: background-color 0.3s ease; 
+  cursor: pointer;
+  font: bold 16px var(--font-main);
+  transition: background 300ms ease; 
   color: white;
-  
 }
 
-/* Styling for links when hovered */
-.primary_link:hover {
-  background-color: black; 
-  text-decoration: underline;
+.primary_link:hover,
+button:hover,
+input[type="button"]:hover,
+input[type="submit"]:hover,
+input[type="reset"]:hover {
+  background: var(--color-dark); 
 }
 
-
+.primary_link:active,
+button:active,
+input[type="button"]:active,
+input[type="submit"]:active,
+input[type="reset"]:active {
+  background: var(--color-darker); 
+}
 
 table {
   border-collapse: collapse;
@@ -101,14 +115,14 @@ table {
 
 /* Style for table headers (column titles) */
 th {
-  background-color: #f2f2f2; /* Background color for headers */
+  background: #f2f2f2; /* Background color for headers */
   padding: 10px;
   text-align: left; /* Align text to the left within headers */
 }
 
 /* Alternating row colors for better readability */
 tr:nth-child(even) {
-  background-color: #f9f9f9; /* Background color for even rows */
+  background: #f9f9f9; /* Background color for even rows */
 }
 
 /* Style for table cells (contents) */
@@ -119,7 +133,7 @@ td {
 
 /* Add some hover effect for better user interaction */
 tr:hover {
-  background-color: #e0e0e0; /* Background color on hover */
+  background: #e0e0e0; /* Background color on hover */
 }
 
 /* Documentation Start */
@@ -135,13 +149,20 @@ body {
   font-family: var(--font-main);
 }
 
-button,
 input[type="text"],
 input[type="number"],
-input[type="submit"],
 select {
+  font: 16px var(--font-main);
   padding: 5px 10px;
-  font-family: var(--font-main);
+  border-radius: 5px;
+  border: 1px solid #AAA;
+}
+
+input[type="text"]:focus,
+input[type="number"]:focus,
+input[type="checkbox"]:focus,
+select:focus {
+  outline: 2px solid var(--color-dark);
 }
 
 input[type="checkbox"] {
@@ -221,7 +242,7 @@ input[type="checkbox"] {
       gap: 10px;
       border-radius: 10px;
       padding: 10px;
-      box-shadow: 0 1px 10px 2px #aaa;
+      box-shadow: 0 1px 10px 2px #AAA;
   }
 
   th{
@@ -234,7 +255,7 @@ input[type="checkbox"] {
 }
 
 nav {
-  background-color: var(--color-main);
+  background: var(--color-main);
   padding: 10px;
   border-radius: 0 0 10px 10px;
   display: block;
@@ -259,11 +280,15 @@ nav a {
   text-decoration: none;
   padding: 8px 12px;
   border-radius: 5px;
-  transition: background-color 0.3s ease;
+  transition: background 300ms ease;
 }
 
 nav a:hover {
-  background-color: black;
+  background: var(--color-dark);
+}
+
+nav a:active {
+  background: var(--color-darker);
 }
 
 .menu-container {
@@ -272,16 +297,18 @@ nav a:hover {
 
 @media screen and (max-width: 600px) {
   nav {
-    background-color: var(--color-main);
+    background: var(--color-main);
     padding: 10px;
     border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 5px rgb(0 0 0 / 0.2);
     position: fixed;
-    top: 50px;
+    top: 60px;
     left: 10px;
     overflow: auto;
     opacity: 1;
     transition: left 500ms, opacity 500ms;
+    box-sizing: border-box;
+    width: min(200px, var(--safe-width));
   }
 
   nav:not(.menu-shown) {
@@ -300,28 +327,28 @@ nav a:hover {
 
   nav a {
     display: block;
-    width: 60px;
     text-decoration: none;
     color: white;
   }
 
   .menu-container {
     border-radius: 5px;
-    background-color: var(--color-main);
+    background: var(--color-main);
     display: inline-block;
     cursor: pointer;
     position: fixed;
     top: 10px;
     left: 10px;
     padding: 5px;
+    box-shadow: 0 2px 5px rgb(0 0 0 / 0.2);
   }
 
   .bar1, .bar2, .bar3 {
     width: 35px;
     height: 5px;
-    background-color: white;
+    background: white;
     margin: 6px 0;
-    transition: 0.4s;
+    transition: all 400ms;
   }
 
 

--- a/app/views/dashboards/admin.html.erb
+++ b/app/views/dashboards/admin.html.erb
@@ -51,7 +51,7 @@
 </table>
 
 <style>
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 700px) {
     #members_table tbody tr td:nth-child(3)::before {
       content: "Points: ";
     }

--- a/app/views/dashboards/admin.html.erb
+++ b/app/views/dashboards/admin.html.erb
@@ -50,6 +50,22 @@
     </tbody>
 </table>
 
+<style>
+  :root {--oof: 600px;}
+  @media screen and (max-width: 600px) {
+    #members_table tbody tr td:first-child {
+      font-size: 24px;
+      font-weight: bold;
+    }
+    #members_table tbody tr td:nth-child(3)::before {
+      content: "Points: ";
+    }
+    #members_table tbody tr td:nth-child(4)::before {
+      content: "Is Admin: ";
+    }
+  }
+</style>
+
 
 <% flash.each do |type, message| %>
     <div class="flash flash-<%= type %>">

--- a/app/views/dashboards/admin.html.erb
+++ b/app/views/dashboards/admin.html.erb
@@ -51,12 +51,7 @@
 </table>
 
 <style>
-  :root {--oof: 600px;}
   @media screen and (max-width: 600px) {
-    #members_table tbody tr td:first-child {
-      font-size: 24px;
-      font-weight: bold;
-    }
     #members_table tbody tr td:nth-child(3)::before {
       content: "Points: ";
     }

--- a/app/views/layouts/_adminmenu.html.erb
+++ b/app/views/layouts/_adminmenu.html.erb
@@ -4,7 +4,7 @@
 
 <div class="navbar">
 
-  <div class="menu-container" onclick="myFunction(this)">
+  <div id="menu_container" onclick="toggleMenu(this)">
     <div class="bar1"></div>
     <div class="bar2"></div>
     <div class="bar3"></div>
@@ -36,9 +36,20 @@
 </script>
 
 <script>
-  function myFunction(x){
+  function toggleMenu(x) {
     x.classList.toggle("change");
     let menu = document.getElementsByTagName("nav")[0];
     menu.classList.toggle("menu-shown");
   }
+
+  // Hide menu when user clicks outside
+  window.addEventListener("click", function(event) {
+    const menuBtn = document.getElementById("menu_container");
+    const menuElem = document.getElementsByTagName("nav")[0];
+    if (menuElem.classList.contains("menu-shown") &&
+        !menuElem.contains(event.target) &&
+        !menuBtn.contains(event.target)) {
+      toggleMenu(menuBtn);
+    }
+  });
 </script>

--- a/app/views/layouts/_adminmenu.html.erb
+++ b/app/views/layouts/_adminmenu.html.erb
@@ -4,11 +4,11 @@
 
 <div class="navbar">
 
-  <div id="menu_container" onclick="toggleMenu(this)">
+  <button id="menu_container" onclick="toggleMenu(this)">
     <div class="bar1"></div>
     <div class="bar2"></div>
     <div class="bar3"></div>
-  </div>
+  </button>
   <nav>
     <ul>
       <li><%= link_to "Home", admin_dashboard_url, aria: {label: "Admin Home Tab"} %></li>

--- a/app/views/layouts/_membermenu.erb
+++ b/app/views/layouts/_membermenu.erb
@@ -4,11 +4,11 @@
 
 <div class="navbar">
 
-  <div id="menu_container" onclick="toggleMenu(this)">
+  <button id="menu_container" onclick="toggleMenu(this)">
     <div class="bar1"></div>
     <div class="bar2"></div>
     <div class="bar3"></div>
-  </div>
+  </button>
   <nav>
     <ul>
       <li><%= link_to "Home", member_dashboard_url(session[:user_id]), aria: {label: "Home Tab"}%></li>

--- a/app/views/layouts/_membermenu.erb
+++ b/app/views/layouts/_membermenu.erb
@@ -4,7 +4,7 @@
 
 <div class="navbar">
 
-  <div class="menu-container" onclick="myFunction(this)">
+  <div id="menu_container" onclick="toggleMenu(this)">
     <div class="bar1"></div>
     <div class="bar2"></div>
     <div class="bar3"></div>
@@ -36,10 +36,21 @@
 </script>
 
 <script>
-  function myFunction(x){
+  function toggleMenu(x){
     x.classList.toggle("change");
     let menu = document.getElementsByTagName("nav")[0];
     menu.classList.toggle("menu-shown");
   }
+
+  // Hide menu when user clicks outside
+  window.addEventListener("click", function(event) {
+    const menuBtn = document.getElementById("menu_container");
+    const menuElem = document.getElementsByTagName("nav")[0];
+    if (menuElem.classList.contains("menu-shown") &&
+        !menuElem.contains(event.target) &&
+        !menuBtn.contains(event.target)) {
+      toggleMenu(menuBtn);
+    }
+  });
 </script>
 

--- a/app/views/reward_confirmations/index.html.erb
+++ b/app/views/reward_confirmations/index.html.erb
@@ -3,31 +3,42 @@
 <br> <br>
 
 <table class="listing" summary="Reward notification list" style="width: 100%;">
-  <tr class="header">
-    <th aria-label="Reward Name">Reward Name</th>
-    <th aria-label="User">User</th>
-    <th aria-label="Purchase Time">Purchase Time</th>
-    <th aria-label="Status">Status</th>
-  </tr>
-  <% @recent_purchases.each do |purchase| %>
-    <tr>
-      <td><%= purchase.reward.name %></td>
-      <td><%= purchase.user.name %></td>
-      <td><%= purchase.created_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
-      <td>
-        <% if purchase.reward_confirmation %>
-          <%= form_with(model: purchase.reward_confirmation, local: true, method: :patch) do |form| %>
-            <%= form.hidden_field :reward_given, value: false %>
-            <%= form.check_box :reward_given, id: dom_id(purchase.reward_confirmation), checked: purchase.reward_confirmation.reward_given, onchange: 'this.form.submit();' %>
-          <% end %>
-        <% else %>
-          Missing
-        <% end %>
-      </td>
+  <thead>
+    <tr class="header">
+      <th aria-label="Reward Name">Reward Name</th>
+      <th aria-label="User">User</th>
+      <th aria-label="Purchase Time">Purchase Time</th>
+      <th aria-label="Status">Status</th>
     </tr>
-  <% end %>
+  </thead>
+  <tbody>
+    <% @recent_purchases.each do |purchase| %>
+      <tr>
+        <td><%= purchase.reward.name %></td>
+        <td><%= purchase.user.name %></td>
+        <td><%= purchase.created_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+        <td>
+          <% if purchase.reward_confirmation %>
+            <%= form_with(model: purchase.reward_confirmation, local: true, method: :patch) do |form| %>
+              <%= form.hidden_field :reward_given, value: false %>
+              <%= form.check_box :reward_given, id: dom_id(purchase.reward_confirmation), checked: purchase.reward_confirmation.reward_given, onchange: 'this.form.submit();' %>
+            <% end %>
+          <% else %>
+            Missing
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
 </table>
-<br />
+<br>
+
+<style>
+  tr:has(input[type="checkbox"]:checked) {
+    opacity: 0.6;
+    color: #333;
+  }
+</style>
 
 <% flash.each do |type, message| %>
   <div class="flash flash-<%= type %>">

--- a/app/views/rewards/purchase.html.erb
+++ b/app/views/rewards/purchase.html.erb
@@ -6,7 +6,7 @@
   <% # url: task_path(@task), method: 'delete' %>
 
   <p>Are you sure you want to purchase this reward?</p>
-  <p><b><i><%= @reward.name %></b></i> for <%= @reward.point_value %> point(s).</p>
+  <p><b><%= @reward.name %></b> for <%= @reward.point_value %> point(s).</p>
 
   <%= link_to("Confirm", handle_purchase_path(id: @reward, user_id: @user), class: "primary_link", aria: {label: "Confirm Purchase Button"})%>
 

--- a/app/views/users/history.html.erb
+++ b/app/views/users/history.html.erb
@@ -79,7 +79,7 @@
 </table>
 
 <style>
-    @media screen and (max-width: 600px) {
+    @media screen and (max-width: 700px) {
         td:nth-child(5)::before { 
             content: "Created At: "; 
             font-weight: bold;

--- a/app/views/users/points.html.erb
+++ b/app/views/users/points.html.erb
@@ -177,26 +177,27 @@
 <style>
 
   #member_table{
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
 
   .member_row{
-      display: flex;
-      flex-direction: row;
-      gap: 10px;
-      border-radius: 10px;
-      padding: 10px;
-      box-shadow: 0 1px 10px 2px #aaa;
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    border-radius: 10px;
+    padding: 10px;
+    box-shadow: 0 1px 10px 2px #aaa;
   }
 
   .member_row div:first-child{
     flex-grow: 1;
+    padding: 4px 0;
   }
 
   .member_row:hover{
-      background-color: #ddd;
+    background-color: #ddd;
   }
 
   .member_row:active{


### PR DESCRIPTION
Added several style fixes. Some key changes are below:

- On mobile, clicking outside the menu now closes it
- Made buttons and navbar links look like other (`primary_link` class) links
- Added hover and active colors to buttons
- Added explicit width for mobile menu
- Focused form elements (input fields, buttons, checkboxes, & dropdowns) now have a dark green outline
- Card bugs fixed for mobile
- Cards now have the card title in a larger font
- Menu icon now has shadow on mobile
- Fixed bug: menu button is now clickable on mobile when there's a flash notice
- z-ordering fixed: menu icon & menu are above the page, and flash notice is above the menu