### PR TITLE
Make sure reward inventory is deducted upon member purchase

### DIFF
--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -21,7 +21,7 @@ class RewardsController < ApplicationController
       saved = true
       ActiveRecord::Base.transaction do
         transaction = @user.spend_transactions.build(points: @reward.point_value, reward_id: @reward.id)
-        unless transaction.save && @user.save
+        unless transaction.save && @user.save && @reward.save
           saved = false
           raise(ActiveRecord::Rollback, 'Failed to save user or transaction')
         end


### PR DESCRIPTION
Bug fix:

- Reward inventory is now deducted by 1 when a member purchases it