### PR TITLE
Fix PWA Service Worker registration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
     <script>
       // Service Worker registration (for PWA)
       if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("sw.js").then(() => console.log("Service Worker registered."));
+        navigator.serviceWorker.register("/sw.js").then(() => console.log("Service Worker registered."));
       }
       else {
         console.warn("Unable to register Service Worker.");


### PR DESCRIPTION
Page now requests `/sw.js` instead of `/dashboards/sw.js`.

I think this would be the *second* one-letter fix we've done in our app 😄